### PR TITLE
Last core charging signals

### DIFF
--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -73,8 +73,8 @@ Vehicle.IsIgnitionOn:
   description: Vehicle ignition status. False - off, True - on.
 
 Vehicle.Powertrain.TractionBattery.Charging.ChargeCurrent.AC:
-  type: sensor
   datatype: float
+  type: sensor
   unit: A
   description: Current AC charging current (rms) at inlet. Negative if returning energy to grid. Used when per-phase numbers are unavailable.
 

--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -71,3 +71,15 @@ Vehicle.IsIgnitionOn:
   type: sensor
   datatype: boolean
   description: Vehicle ignition status. False - off, True - on.
+
+Vehicle.Powertrain.TractionBattery.Charging.ChargeCurrent.AC:
+  type: sensor
+  datatype: float
+  unit: A
+  description: Current AC charging current (rms) at inlet. Negative if returning energy to grid. Used when per-phase numbers are unavailable.
+
+Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.Actual:
+  datatype: float
+  type: sensor
+  unit: V
+  description: Current charging voltage at inlet. Used when the source does not distinguish between AC and DC voltage.

--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -82,4 +82,4 @@ Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.UnknownType:
   datatype: float
   type: sensor
   unit: V
-  description: Current charging voltage at inlet. Used when the source does not indicate which type of current (AC or DC) is being used.
+  description: Current charging voltage at inlet. Used when the data source does not indicate the current type (AC or DC) in use.

--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -78,7 +78,7 @@ Vehicle.Powertrain.TractionBattery.Charging.ChargeCurrent.AC:
   unit: A
   description: Current AC charging current (rms) at inlet. Negative if returning energy to grid. Used when per-phase numbers are unavailable.
 
-Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.Actual:
+Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.UnknownType:
   datatype: float
   type: sensor
   unit: V

--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -82,4 +82,4 @@ Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.UnknownType:
   datatype: float
   type: sensor
   unit: V
-  description: Current charging voltage at inlet. Used when the source does not distinguish between AC and DC voltage.
+  description: Current charging voltage at inlet. Used when the source does not indicate which type of current (AC or DC) is being used.


### PR DESCRIPTION
Pulling two signals from #9. These seem like the other important charging measurements. We can negotiate the rest tomorrow.

We are searching for target VSS signals for two [Tesla signals](https://developer.tesla.com/docs/fleet-api/fleet-telemetry/available-data):

1. `ChargeAmps`: This is indeed in amps. The description is "AC charger's sensed input line current". True to that description, the signal only shows up during AC charging. VSS has `Charging.ChargeCurrent.Phase{1,2,3}`. Most home chargers are one-phase, but in Europe there are some [three-phase](https://en.wikipedia.org/wiki/Three-phase_electric_power). I'm trying to find one in order to confirm that this is the average current across the three phases (you expect them to roughly be the same) in those cases.
2. `ChargerVoltage`. This is in volts. The description is "RMS value of AC charger's sensed input voltage". This turns out to be misleading and in fact we're sent this value during DC charging as well. VSS has `Charging.ChargeVoltage.Phase{1,2,3}` for AC and `Charging.ChargeVoltage.DC` for DC. We need something universal. ~~I've picked "Actual" out of a hat—"Current" would be great except it's an overloaded word in this file. "Measured" would also be fine.~~ I went with `UnknownType` to be explicit. I could not bring myself to do `UnknownCurrentType`.