### PR TITLE
Make range in kilometers official

### DIFF
--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -57,8 +57,8 @@ RelativeLevel:
 Range:
   datatype: uint32
   type: sensor
-  unit: m
-  description: Remaining range in meters using only liquid fuel.
+  unit: km
+  description: Remaining range in kilometers using only liquid fuel.
 
 TimeRemaining:
   datatype: uint32

--- a/spec/Powertrain/Powertrain.vspec
+++ b/spec/Powertrain/Powertrain.vspec
@@ -15,8 +15,8 @@ AccumulatedBrakingEnergy:
 Range:
   datatype: uint32
   type: sensor
-  unit: m
-  description: Remaining range in meters using all energy sources available in the vehicle.
+  unit: km
+  description: Remaining range in kilometers using all energy sources available in the vehicle.
 
 TimeRemaining:
   datatype: uint32

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -223,8 +223,8 @@ PowerLoss:
 Range:
   datatype: uint32
   type: sensor
-  unit: m
-  description: Remaining range in meters using only battery.
+  unit: km
+  description: Remaining range in kilometers using only battery.
 
 TimeRemaining:
   datatype: uint32


### PR DESCRIPTION
We've long used kilometers for ranges instead of the VSS standard's meters. Everyone I've talked to prefers kilometers, and there's little appetite for going back to edit existing rows and then updating all clients, so let's change our fork of the standard to reflect reality.