### PR TITLE
Add new Vehicle.CurrentLocation.Coordinates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ yaml:
 	${TOOLSDIR}/vspec2yaml.py -I ./spec -o overlays/DIMO/dimo.vspec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$(VSS_VERSION).yaml
 
 csv:
-	${TOOLSDIR}/vspec2csv.py -I ./spec -o overlays/DIMO/dimo.vspec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$(VSS_VERSION).csv
+	${TOOLSDIR}/vspec2csv.py -I ./spec -vt overlays/DIMO/types.vspec -o overlays/DIMO/dimo.vspec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$(VSS_VERSION).csv
 
 ddsidl:
 	${TOOLSDIR}/vspec2ddsidl.py -I ./spec -o overlays/DIMO/dimo.vspec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$(VSS_VERSION).idl

--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -15,6 +15,10 @@ Vehicle.DIMO.Aftermarket:
   description: holds information about the aftermarket dimo device
 #include aftermarket.vspec Vehicle.DIMO.Aftermarket
 
+Vehicle.CurrentLocation.Coordinates:
+  type: sensor
+  datatype: Types.DIMO.Coordinates
+  description: Current location of the vehicle in WGS 84 coordinates.
 
 Vehicle.DIMO.Subject:
   type: sensor

--- a/overlays/DIMO/types.vspec
+++ b/overlays/DIMO/types.vspec
@@ -1,0 +1,34 @@
+Types:
+  type: branch
+  description: Type definitions
+
+Types.DIMO:
+  type: branch
+  description: DIMO-specific types
+
+Types.DIMO.Coordinates:
+  type: struct
+  description: A struct datatype representing GNSS position.
+
+Types.DIMO.Coordinates.Latitude:
+  datatype: double
+  type: property
+  min: -90
+  max: 90
+  unit: degrees
+  description: Latitude in WGS 84 coordinates.
+
+Types.DIMO.Coordinates.Longitude:
+  datatype: double
+  type: property
+  min: -180
+  max: 180
+  unit: degrees
+  description: Longitude in WGS 84 coordinates.
+
+Types.DIMO.Coordinates.HDOP:
+  datatype: double
+  type: property
+  min: 0
+  unit: ratio
+  description: Horizontal dilution of position. May be zero if this was not measured.


### PR DESCRIPTION
This has a new custom struct type, denoted by `Types.DIMO.Coordinates`. When I run
```sh
make venv
source .venv/vss-tools/bin/activate
make csv
```
I get some new rows:
```csv
"Node","Type","DataType","Deprecated","Unit","Min","Max","Desc","Comment","Allowed","Default","Id"
"Vehicle.CurrentLocation.Coordinates","sensor","Types.DIMO.Coordinates","","","","","Current location of the vehicle in WGS 84 coordinates.","","","","7fe502d879175cd5a85353d036e47a66"
"Types.DIMO.Coordinates","struct","","","","","","A struct datatype representing GNSS position.","","","","eda1e3476a3f5bda868c618c26654a2b"
"Types.DIMO.Coordinates.Latitude","property","double","","degrees","-90","90","Latitude in WGS 84 coordinates.","","","","92623867ef575aad848a8ad87f30ac2a"
"Types.DIMO.Coordinates.Longitude","property","double","","degrees","-180","180","Longitude in WGS 84 coordinates.","","","","37bd9a0850205a01b3f31a09e4bb7a1c"
"Types.DIMO.Coordinates.HDOP","property","double","","ratio","0","","Horizontal dilution of position. May be zero if this was not measured.","","","","53fd9d707b1153e796f4a65e21c9808b"
```

That first non-header row is the one we really want. I don't plan to create a general VSS struct → Go struct regime.