### PR TITLE
Charing Power VSS, according to R1 notion

### DIFF
--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -88,7 +88,7 @@ Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.UnknownType:
   unit: V
   description: Current charging voltage at inlet. Used when the data source does not indicate the current type (AC or DC) in use.
 
-Vehicle.Powertrain.TractionBattery.Charging.Power
+Vehicle.Powertrain.TractionBattery.Charging.Power:
   datatype: float
   type: sensor
   unit: kW

--- a/overlays/DIMO/dimo.vspec
+++ b/overlays/DIMO/dimo.vspec
@@ -87,3 +87,9 @@ Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.UnknownType:
   type: sensor
   unit: V
   description: Current charging voltage at inlet. Used when the data source does not indicate the current type (AC or DC) in use.
+
+Vehicle.Powertrain.TractionBattery.Charging.Power
+  datatype: float
+  type: sensor
+  unit: kW
+  description: Instantaneous charging power recorded during a charging event.

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -479,12 +479,6 @@ Charging.ChargeVoltage.Phase3:
   unit: V
   description: Current AC charging voltage (rms) at inlet for Phase 3.
 
-Charging.Power:
-  datatype: float
-  type: sensor
-  unit: kW
-  description: Instantaneous charging power recorded during a charging event.
-
 Charging.AveragePower:
   datatype: float
   type: sensor

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -483,7 +483,7 @@ Charging.Power:
   datatype: float
   type: sensor
   unit: kW
-  description: Instantaneous charging power of the last or current charging event.
+  description: Instantaneous charging power recorded during a charging event.
 
 Charging.AveragePower:
   datatype: float

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -479,6 +479,12 @@ Charging.ChargeVoltage.Phase3:
   unit: V
   description: Current AC charging voltage (rms) at inlet for Phase 3.
 
+Charging.Power:
+  datatype: float
+  type: sensor
+  unit: kW
+  description: Instantaneous charging power of the last or current charging event.
+
 Charging.AveragePower:
   datatype: float
   type: sensor


### PR DESCRIPTION
@KevinJoiner Can you approve this so I can finalize mappin of EV signals.

R1 Notion:

type: float
Unit: kW
Description: current power drawn from the charger during a charging session.