### PR TITLE
Adding PID 164 Actual Gear Transmission

### DIFF
--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -51,6 +51,20 @@ TravelledDistance:
   description: Odometer reading, total distance travelled during the lifetime of the transmission.
 
 #
+# Actual Gear
+#
+
+ActualGear:
+  type: sensor
+  datatype: int8
+  description: Actual transmission gear currently engaged. 0 = neutral, 1-15 = gear number.
+
+ActualGearRatio:
+  type: sensor
+  datatype: float
+  description: Actual transmission gear ratio.
+
+#
 # Current gear
 #
 CurrentGear:


### PR DESCRIPTION
@zer0stars 

A new VSS signal to represent the physically engaged transmission gear reported by the OBD signal (PID 164). ActualGear is used instead of CurrentGear to avoid ambiguity and clearly indicate the gear that is actually engaged in the transmission.